### PR TITLE
toolchaini/gcc: fix libstdc++ dual abi model

### DIFF
--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -118,7 +118,7 @@ GCC_CONFIGURE:= \
 		--disable-decimal-float \
 		--with-diagnostics-color=auto-if-env \
 		--enable-__cxa_atexit \
-		--disable-libstdcxx-dual-abi \
+		--enable-libstdcxx-dual-abi \
 		--with-default-libstdcxx-abi=new
 ifneq ($(CONFIG_mips)$(CONFIG_mipsel),)
   GCC_CONFIGURE += --with-mips-plt


### PR DESCRIPTION
libstdcxx-dual-abi needs to be enabled to actually support C++11 ABI. Enable the config flag to also permit support of .NET 6 development on OpenWrt.

https://github.com/openwrt/openwrt/commit/c0b4303d2e2f4a9e1d4684fd584e6b6548666f0f

https://github.com/openwrt/packages/issues/20340

maybe fix #88