### PR TITLE
defconfig: enable umdns by default

### DIFF
--- a/defconfig/mt7981-ax3000.config
+++ b/defconfig/mt7981-ax3000.config
@@ -243,6 +243,7 @@ CONFIG_PACKAGE_swconfig=y
 CONFIG_PACKAGE_switch=y
 CONFIG_PACKAGE_tcpdump=y
 CONFIG_PACKAGE_terminfo=y
+CONFIG_PACKAGE_umdns=y
 CONFIG_PACKAGE_wifi-profile=y
 CONFIG_PACKAGE_wireless-regdb=y
 CONFIG_PACKAGE_wireless-tools=y

--- a/defconfig/mt7986-ax6000.config
+++ b/defconfig/mt7986-ax6000.config
@@ -240,6 +240,7 @@ CONFIG_PACKAGE_swconfig=y
 CONFIG_PACKAGE_switch=y
 CONFIG_PACKAGE_tcpdump=y
 CONFIG_PACKAGE_terminfo=y
+CONFIG_PACKAGE_umdns=y
 CONFIG_PACKAGE_wifi-profile=y
 CONFIG_PACKAGE_wireless-regdb=y
 CONFIG_PACKAGE_wireless-tools=y


### PR DESCRIPTION
mDNS, also known as Bonjour or zero-configuration networking (ZeroConf) or DNS Service Discovery (DNS-SD), enables automatic discovery of computers, devices, and services on IP networks. It is an internet standard documented in [RFC6762](https://tools.ietf.org/html/rfc6762).

The [umdns](https://openwrt.org/packages/pkgdata/umdns) package provides a compact implementation of this standard, well integrated with the OpenWrt system environment. In particular, almost all interaction with the daemon is via [ubus](https://openwrt.org/docs/guide-developer/ubus).

https://openwrt.org/docs/guide-developer/mdns