### PR TITLE
mediatek: fix the incorrect network port sequence of CMCC RAX3000M

### DIFF
--- a/target/linux/mediatek/mt7981/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7981/base-files/etc/board.d/02_network
@@ -49,11 +49,15 @@ mediatek_setup_interfaces()
 			"1:lan" "2:lan" "3:lan" "0:wan" "6t@eth0"
 		;;
 	h3c,nx30pro |\
-	*konka,komi-a31* |\
-	*rax3000m*)
+	*konka,komi-a31*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "6u@eth0"
+		;;
+	*rax3000m*)
+		ucidef_set_interfaces_lan_wan "eth0" "eth1"
+		ucidef_add_switch "switch0" \
+			"0:lan:3" "1:lan:2" "2:lan:1" "6u@eth0"
 		;;
 	*mt3000* |\
 	glinet,x3000-emmc |\


### PR DESCRIPTION
重新pr，已这个为准。