### PR TITLE
Revert "defconfig: enable umdns by default (#100)"

### DIFF
--- a/defconfig/mt7981-ax3000.config
+++ b/defconfig/mt7981-ax3000.config
@@ -290,7 +290,6 @@ CONFIG_PACKAGE_swconfig=y
 CONFIG_PACKAGE_switch=y
 CONFIG_PACKAGE_tcpdump=y
 CONFIG_PACKAGE_terminfo=y
-CONFIG_PACKAGE_umdns=y
 CONFIG_PACKAGE_wifi-profile=y
 CONFIG_PACKAGE_wireless-regdb=y
 CONFIG_PACKAGE_wireless-tools=y

--- a/defconfig/mt7986-ax6000.config
+++ b/defconfig/mt7986-ax6000.config
@@ -277,7 +277,6 @@ CONFIG_PACKAGE_swconfig=y
 CONFIG_PACKAGE_switch=y
 CONFIG_PACKAGE_tcpdump=y
 CONFIG_PACKAGE_terminfo=y
-CONFIG_PACKAGE_umdns=y
 CONFIG_PACKAGE_wifi-profile=y
 CONFIG_PACKAGE_wireless-regdb=y
 CONFIG_PACKAGE_wireless-tools=y


### PR DESCRIPTION
This reverts commit c2727b389c5c7f11eca27d701fedc64ddb7952aa.

Some applications (e.g. `samba4`) use `avahi` to provide mDNS support.