### PR TITLE
修复时区问题

### DIFF
--- a/target/linux/mediatek/Makefile
+++ b/target/linux/mediatek/Makefile
@@ -14,6 +14,6 @@ KERNEL_TESTING_PATCHVER:=5.4
 include $(INCLUDE_DIR)/target.mk
 DEFAULT_PACKAGES += \
 	kmod-leds-gpio kmod-gpio-button-hotplug \
-	autocore-arm uboot-envtools mtk-smp
+	autocore-arm uboot-envtools mtk-smp zoneinfo-core zoneinfo-asia
 
 $(eval $(call BuildTarget))


### PR DESCRIPTION
某些docker容器会因缺少时区组件导致无法启动
例如：Home Assistant