### PR TITLE
mediatek: fix xdr608x eth & wifi mac addr

### DIFF
--- a/target/linux/mediatek/mt7986/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7986/base-files/etc/board.d/02_network
@@ -89,19 +89,20 @@ mediatek_setup_macs()
 		;;
  	tplink,tl-xdr6086|\
  	tplink,tl-xdr6088)
- 		wan_mac=$(mtd_get_mac_binary config 0x1c)
- 		lan_mac=$(macaddr_add "$wan_mac" 1)
-		local b0dat="$(l1dat if2dat ra0)"
-		local b1dat="$(l1dat if2dat rax0)"
-		if [ -f ${b0dat} ] && ! grep -q "MacAddress=" ${b0dat}; then
-			local b0mac="$(macaddr_add $label_mac 2)"
-			echo "MacAddress=$b0mac" >> ${b0dat}
-		fi
-		if [ -f ${b1dat} ] && ! grep -q "MacAddress=" ${b1dat}; then
-			local b1mac="$(macaddr_add $label_mac 3)"
-			echo "MacAddress=$b1mac" >> ${b1dat}
-		fi
-		;;
+                lan_mac=$(mtd_get_mac_binary config 0x1c)
+                wan_mac=$(macaddr_add "$lan_mac" 1)
+                label_mac=$lan_mac
+                local b0dat="$(l1dat if2dat ra0)"
+                local b1dat="$(l1dat if2dat rax0)"
+                if [ -f ${b0dat} ] && ! grep -q "MacAddress=" ${b0dat}; then
+                        local b0mac="$label_mac"
+                        echo "MacAddress=$b0mac" >> ${b0dat}
+                fi
+                if [ -f ${b1dat} ] && ! grep -q "MacAddress=" ${b1dat}; then
+                        local b1mac="$(macaddr_add $label_mac 2)"
+                        echo "MacAddress=$b1mac" >> ${b1dat}
+                fi
+                ;;
 	xiaomi,redmi-router-ax6000*)
 		wan_mac=$(mtd_get_mac_ascii Bdata ethaddr_wan)
 		lan_mac=$(mtd_get_mac_ascii Bdata ethaddr)


### PR DESCRIPTION
fix add last commit missing `$label_mac `and set xdr608x’s eth & mac address same as stock firmware: 
```
$(mtd_get_mac_binary config 0x1c) = <label_mac>=<lan_mac>=<ra0_mac>
<wan_mac>=<lan_mac>+1
<rax0_mac>=<lan_mac>+2
```