### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To build your own firmware you need a GNU/Linux, BSD or MacOSX system (case sens
           g++-multilib git gperf haveged help2man intltool lib32gcc-s1 libc6-dev-i386 libelf-dev libglib2.0-dev \
           libgmp3-dev libltdl-dev libmpc-dev libmpfr-dev libncurses5-dev libncursesw5 libncursesw5-dev libreadline-dev \
           libssl-dev libtool lld lldb lrzsz mkisofs msmtp nano ninja-build p7zip p7zip-full patch pkgconf python2.7 \
-          python3 python3-pip python3-ply python-docutils qemu-utils re2c rsync scons squashfs-tools subversion swig \
+          python3 python3-pip python3-ply python3-docutils qemu-utils re2c rsync scons squashfs-tools subversion swig \
           texinfo uglifyjs upx-ucl unzip vim wget xmlto xxd zlib1g-dev
         ```
       </details>


### PR DESCRIPTION
fix package: python-docutils not available, in requirements guide, use python3-docutils instead of.
ref: https://build-scripts.immortalwrt.eu.org/init_build_environment.sh line:171