### PR TITLE
mediatek: add Nokia EA0326GMP support

### DIFF
--- a/package/mtk/applications/mtk-smp/files/smp.sh
+++ b/package/mtk/applications/mtk-smp/files/smp.sh
@@ -757,6 +757,7 @@ setup_model()
 	*rax3000m* |\
 	h3c,nx30pro |\
 	konka,komi-a31 |\
+	*nokia,ea0326gmp* |\
 	nradio,wt9103 |\
 	*7981*)
 		MT7981_whnat $num_of_wifi $usbnet

--- a/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7981-nokia-ea0326gmp.dts
+++ b/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7981-nokia-ea0326gmp.dts
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "Nokia EA0326GMP";
+	compatible = "nokia,ea0326gmp", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &power_led;
+		led-running = &power_led;
+		led-failsafe = &power_led;
+		led-upgrade = &power_led;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n1 loglevel=8 earlycon=uart8250,mmio32,0x11002000";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x10000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power_led: led-0 {
+			label = "green:power";
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			label = "green:wan";
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			label = "red:wan";
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			label = "green:lan";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			label = "green:wlan";
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			label = "green:wps";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gsw: gsw@0 {
+		compatible = "mediatek,mt753x";
+		mediatek,ethsys = <&ethsys>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	nmbm_spim_nand {
+		compatible = "generic,nmbm";
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		lower-mtd-device = <&spi_nand>;
+		forced-create;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+			};
+
+			partition@580000 {
+				label = "Config";
+				reg = <0x580000 0x200000>;
+			};
+
+			partition@780000 {
+				label = "Config2";
+				reg = <0x780000 0x200000>;
+			};
+
+			partition@980000 {
+				label = "ubi";
+				reg = <0x980000 0x6e00000>;
+			};
+
+			/* Leave last 8.5 MiB for NMBM bad block table */
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&phy0>;
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@0 {
+			compatible = "ethernet-phy-id03a2.9461";
+			reg = <0>;
+			phy-mode = "gmii";
+			nvmem-cells = <&phy_calibration>;
+			nvmem-cell-names = "phy-cal-data";
+		};
+	};
+};
+
+&gsw {
+	mediatek,mdio = <&mdio>;
+	mediatek,mdio_master_pinmux = <0>;
+	reset-gpios = <&pio 39 0>;
+	interrupt-parent = <&pio>;
+	interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	status = "okay";
+
+	port6: port@6 {
+		compatible = "mediatek,mt753x-port";
+		mediatek,ssc-on;
+		reg = <6>;
+		phy-mode = "sgmii";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+		};
+	};
+};
+
+&hnat {
+        mtketh-wan = "eth1";
+        mtketh-lan = "eth0";
+        mtketh-max-gmac = <2>;
+        status = "okay";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <8>;
+			bias-pull-up = <103>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <8>;
+			bias-pull-down = <103>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/mediatek/image/mt7981.mk
+++ b/target/linux/mediatek/image/mt7981.mk
@@ -520,6 +520,23 @@ define Device/imou_lc-hx3001
 endef
 TARGET_DEVICES += imou_lc-hx3001
 
+define Device/nokia_ea0326gmp
+  DEVICE_VENDOR := Nokia
+  DEVICE_MODEL := EA0326GMP
+  DEVICE_DTS := mt7981-nokia-ea0326gmp
+  DEVICE_DTS_DIR := $(DTS_DIR)/mediatek
+  SUPPORTED_DEVICES := nokia,ea0326gmp
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 112640k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += nokia_ea0326gmp
+
 define Device/nradio_wt9103
   DEVICE_VENDOR := NRADIO
   DEVICE_MODEL := WT9103

--- a/target/linux/mediatek/mt7981/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/mt7981/base-files/etc/board.d/01_leds
@@ -21,7 +21,8 @@ clt,r30b1)
 	ucidef_set_led_default "internet" "INTERNET" "led_internet" "1"
 	ucidef_set_led_default "power_red" "POWER_RED" "led_power" "0"
 	;;
-imou,lc-hx3001)
+imou,lc-hx3001|\
+nokia,ea0326gmp)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link"
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link"
 	ucidef_set_led_netdev "wlan" "WLAN" "green:wlan" "rax0" "link"

--- a/target/linux/mediatek/mt7981/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7981/base-files/etc/board.d/02_network
@@ -3,6 +3,7 @@
 . /lib/functions.sh
 . /lib/functions/uci-defaults.sh
 . /lib/functions/system.sh
+. /lib/functions/caldata.sh
 
 mediatek_setup_interfaces()
 {
@@ -62,6 +63,11 @@ mediatek_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:3" "1:lan:2" "2:lan:1" "6u@eth0"
 		;;
+	*nokia,ea0326gmp*)
+		ucidef_set_interfaces_lan_wan "eth0" "eth1"
+		ucidef_add_switch "switch0" \
+			"1:lan" "2:lan" "3:lan" "6u@eth0"
+		;;
 	*mt3000* |\
 	glinet,x3000-emmc |\
 	*xe3000* |\
@@ -89,18 +95,12 @@ mtk_facrory_write_mac()
 	local macaddr=$3 #aa:bb:cc:dd:ee:ff
 	local data=""
 
-	part=$(find_mtd_part $part_name)
+	part="$(find_mtd_part $part_name)"
 	if [ -n "$part" ] && [ -n "$macaddr" ]; then
-		local i=1
-		for x in ${macaddr//:/ }; do
-			[ $i -gt 6 ] && break
-			data=${data}"\x${x}"
-			i=$((i+1))
-		done
-		dd if=$part of=/tmp/Factory.backup
-		printf "${data}" | dd conv=notrunc of=/tmp/Factory.backup bs=1 seek=$((${offset}))
-		mtd write /tmp/Factory.backup $part_name
-		rm -rf /tmp/Factory.backup
+		dd if="$part" of="/tmp/Factory.backup"
+		caldata_patch_mac "$macaddr" "0x4" "" "/tmp/Factory.backup"
+		mtd write "/tmp/Factory.backup" "$part_name"
+		rm -rf "/tmp/Factory.backup"
 	fi
 }
 
@@ -200,6 +200,16 @@ mediatek_setup_macs()
 			local wifi_mac=$(mtd_get_mac_binary Factory 0x4)
 			lan_mac=$(macaddr_add $wifi_mac -1)
 			wan_mac=$(macaddr_add $wifi_mac 1)
+		fi
+		;;
+	nokia,ea0326gmp)
+		lan_mac=$(mtd_get_mac_binary Factory 0x28)
+		wan_mac=$(macaddr_add $lan_mac 3)
+		label_mac=$wan_mac
+
+		if [ "$(mtk_factory_get_byte Factory 4 2)" = "00-0c" ]; then
+			local wifi_mac="$(macaddr_add $lan_mac 1)"
+			mtk_facrory_write_mac Factory 4 "$wifi_mac"
 		fi
 		;;
 	nradio,wt9103)

--- a/target/linux/mediatek/mt7981/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7981/base-files/lib/upgrade/platform.sh
@@ -205,6 +205,7 @@ platform_do_upgrade() {
 	cmcc,rax3000m |\
 	h3c,nx30pro |\
 	*konka,komi-a31* |\
+	*nokia,ea0326gmp* |\
 	*snand*)
 		nand_do_upgrade "$1"
 		;;
@@ -251,6 +252,7 @@ platform_check_image() {
 	cmcc,rax3000m* |\
 	h3c,nx30pro |\
 	*konka,komi-a31* |\
+	*nokia,ea0326gmp* |\
 	nradio,wt9103 |\
 	*snand* |\
 	*emmc*)


### PR DESCRIPTION
```
Hardware specification:
  SoC: MediaTek MT7981B 2x A53
  Flash: 128 MB SPI-NAND
  RAM: 256MB
  Ethernet: 4x 10/100/1000 Mbps
  Switch: MediaTek MT7531AE
  WiFi: MediaTek MT7976C
  Button: Reset, WPS/Mesh
  Power: DC 12V 1A

Gain SSH access:
1. Login into web interface, and download the configuration.
2. Download the configration utilities:
   https://firmware.download.immortalwrt.eu.org/cnsztl/mediatek/filogic/openwrt-mediatek-mt7981-nokia-ea0326gmp-config-utils.tar.gz
     These binaries are extraced from the factory firmware, which are
     dynamically linked with aarch64 musl 1.1.24. To use them, you
     must run them under the same runtime environment, otherwise the
     binaries will not work!
3. Upload the configuration and utilities to a suitable environment.
4. Uncompress the utilities, move them to '/bin' and give them executable permisison:
   tar -zxf openwrt-mediatek-mt7981-nokia-ea0326gmp-config-utils.tar.gz
   mv mkconfig seama /bin
   chmod +x /bin/mkconfig
   chmod +x /bin/seama
5. Decrypt and uncompress the configuration:
     Enter fakeroot if you are not login as root.
   mkconfig -a de-enca -m EA0326GMP_3FE79221BAAA -i EA0326GMP_3FE79221BAAA-xxxxxxxx-backup.tar.gz -o backup.tar.gz
   tar -zxf backup.tar.gz
6. Edit 'etc/config/dropbear', set 'enable' to '1'.
7. Edit `etc/passwd`, remove root password: 'root::1:0:99999:7:::'.
8. Repack the configuration:
   tar -zcf backup.tar.gz etc/
   mkconfig -a enca -m EA0326GMP_3FE79221BAAA -i backup.tar.gz -o EA0326GMP_3FE79221BAAA-xxxxxxxx-backup.tar.gz
9. Upload new configuration via web interface, now you can SSH to EA0326GMP.

A minimum configuration which enabled SSH access is also provided to simplify the process:
https://firmware.download.immortalwrt.eu.org/cnsztl/mediatek/filogic/openwrt-mediatek-mt7981-nokia-ea0326gmp-enable-ssh.tar.gz

Flash instructions:
1. SSH to EA0326GMP, backup everything, especially 'Factory' part.
2. Write new FIP provided by https://github.com/hanwckf/bl-mt798x.
3. Reboot, enter web failsafe and upload -factory.bin firmware.
```