### PR TITLE
Change spi group to fix LED bug

### DIFF
--- a/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-netcore-n60.dts
+++ b/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-netcore-n60.dts
@@ -292,7 +292,7 @@
 
 &spi1 {
  	pinctrl-names = "default";
- 	pinctrl-0 = <&spic_pins_g2>;
+ 	pinctrl-0 = <&spic_pins_g1>;
  	status = "okay";
  };
 


### PR DESCRIPTION
spic_pins_g2 was conflict with LED's GPIO, change it to spic_pins_g1 to fix it.