### PR TITLE
mediatek: fix PCIe #PERST being de-asserted too early

### DIFF
--- a/target/linux/mediatek/patches-5.4/611-pcie-mediatek-gen3-PERST-for-100ms.patch
+++ b/target/linux/mediatek/patches-5.4/611-pcie-mediatek-gen3-PERST-for-100ms.patch
@@ -1,0 +1,17 @@
+--- a/drivers/pci/controller/pcie-mediatek-gen3.c
++++ b/drivers/pci/controller/pcie-mediatek-gen3.c
+@@ -317,7 +317,13 @@ static int mtk_pcie_startup_port(struct
+ 	msleep(100);
+ 
+ 	/* De-assert reset signals */
+-	val &= ~(PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB | PCIE_PE_RSTB);
++	val &= ~(PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB);
++	writel_relaxed(val, port->base + PCIE_RST_CTRL_REG);
++
++	msleep(100);
++
++	/* De-assert PERST# signals */
++	val &= ~(PCIE_PE_RSTB);
+ 	writel_relaxed(val, port->base + PCIE_RST_CTRL_REG);
+ 
+ 	/* Check if the link is up or not */


### PR DESCRIPTION
The driver for MediaTek gen3 PCIe hosts de-asserts all reset signals at the same time using a single register write operation. Delay the de-assertion of the #PERST signal by 100ms as some PCIe devices fail to come up otherwise.

Sync from https://github.com/immortalwrt/immortalwrt/commit/6a2e17d5c1

Test on CLX S20P: When using the original driver, the Hikvision C2000Pro 512GB NVMe worked fine, but the Steam Deck 64G NVMe drive (E2M2 64GB MCF433D002F1C) could not boot properly. After applying the patch, the Steam Deck 64G NVMe drive also worked properly.

Without patch:
```
root@ImmortalWrt:~# lspci
0000:00:00.0 Unclassified device [0002]: MEDIATEK Corp. Device 7986
0001:00:00.0 PCI bridge: MEDIATEK Corp. Device 1f32 (rev 01)
0001:01:00.0 Non-Volatile memory controller: O2 Micro, Inc. Device 8760 (rev 01)
root@ImmortalWrt:~# dmesg | grep nvme
[   22.900957] nvme 0001:01:00.0: assign IRQ: got 131
[   22.905922] nvme nvme0: pci function 0001:01:00.0
[   22.921403] nvme 0001:01:00.0: enabling device (0000 -> 0002)
[   22.927165] nvme 0001:01:00.0: enabling bus mastering
[   53.494815] nvme nvme0: Device not ready; aborting initialisation
[   53.500909] nvme nvme0: Removing after probe failure status: -19
```

With patch:
```
root@ImmortalWrt:~# lspci
0000:00:00.0 Unclassified device [0002]: MEDIATEK Corp. Device 7986
0001:00:00.0 PCI bridge: MEDIATEK Corp. Device 1f32 (rev 01)
0001:01:00.0 Non-Volatile memory controller: O2 Micro, Inc. Device 8760 (rev 01)
root@ImmortalWrt:~# dmesg | grep nvme
[   22.964122] nvme 0001:01:00.0: assign IRQ: got 131
[   22.969057] nvme nvme0: pci function 0001:01:00.0
[   22.984406] nvme 0001:01:00.0: enabling device (0000 -> 0002)
[   22.990154] nvme 0001:01:00.0: enabling bus mastering
[   23.103316] nvme nvme0: missing or invalid SUBNQN field.
[   23.109143] nvme nvme0: 1/0/0 default/read/poll queues
[   23.127251]  nvme0n1: p1
```