### PR TITLE
mediatek: mt7981: add support for HiLink RM65

### DIFF
--- a/target/linux/mediatek/base-files/etc/uci-defaults/99-hilink-rm65-ssid
+++ b/target/linux/mediatek/base-files/etc/uci-defaults/99-hilink-rm65-ssid
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+board="$(board_name)"
+
+case "$board" in
+    hilink,rm65|hilink_rm65)
+        echo "[RM65] Initializing SSID auto-suffix..."
+
+        #
+        # Detect the Factory partition in MTD
+        #
+        FACTORY_MTD=$(grep -i '"Factory"' /proc/mtd | cut -d: -f1)
+
+        if [ -z "$FACTORY_MTD" ]; then
+            echo "[RM65] ERROR: Factory partition not found in /proc/mtd"
+            exit 0
+        fi
+
+        FACTORY="/dev/${FACTORY_MTD}"
+
+        if [ ! -e "$FACTORY" ]; then
+            echo "[RM65] ERROR: Factory device ${FACTORY} does not exist"
+            exit 0
+        fi
+
+        #
+        # Read 2 bytes from Factory offset 0x08 as SSID suffix
+        #
+        mac_suffix="$(
+            hexdump -s 0x8 -n 2 "$FACTORY" 2>/dev/null \
+            | head -n 1 \
+            | tr -d ' ' \
+            | tr -d '\n' \
+            | tail -c 4
+        )"
+
+        if [ -z "$mac_suffix" ]; then
+            echo "[RM65] ERROR: Failed to read SSID suffix from ${FACTORY}"
+            exit 0
+        fi
+
+        echo "[RM65] SSID suffix detected: ${mac_suffix}"
+
+        #
+        # Update default SSID in Mediatek WiFi dat files
+        #
+        sed -i "s/HiLink_AX3000_2.4G/HLK_AX3000_2G_${mac_suffix}/g" \
+            /etc/wireless/mediatek/mt7981.dbdc.b0.dat 2>/dev/null
+
+        sed -i "s/HiLink_AX3000_5G/HLK_AX3000_5G_${mac_suffix}/g" \
+            /etc/wireless/mediatek/mt7981.dbdc.b1.dat 2>/dev/null
+
+        echo "[RM65] SSID updated successfully."
+        ;;
+esac
+
+exit 0

--- a/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7981-hilink-rm65.dts
+++ b/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7981-hilink-rm65.dts
@@ -1,0 +1,339 @@
+/dts-v1/;
+#include "mt7981.dtsi"
+/ {
+	model = "HiLink RM65";
+	compatible = "hilink,rm65", "mediatek,mt7981";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n1 loglevel=8  \
+				earlycon=uart8250,mmio32,0x11002000";
+	};
+
+	memory {
+		// 256MB DDR: 128MB*2
+		reg = <0 0x40000000 0 0x10000000>;
+	};
+
+	gpio-keys {
+			compatible = "gpio-keys";
+				reset {
+					label = "reset";
+					linux,code = <KEY_RESTART>;
+					gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+				};
+
+				wps {
+					label = "wps";
+					linux,code = <KEY_WPS_BUTTON>;
+					gpios = <&pio 0 GPIO_ACTIVE_HIGH>;
+				};
+	};
+
+        leds {
+                compatible = "gpio-leds";
+
+		wan_led1 {
+		    label = "rm65:green:wan_recv";
+		    gpios = <&pio 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_led2 {
+		    label = "rm65:green:wan_send";
+		    gpios = <&pio 13 GPIO_ACTIVE_HIGH>;
+		};
+        };
+
+	nmbm_spim_nand {
+		compatible = "generic,nmbm";
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		lower-mtd-device = <&spi_nand>;
+		forced-create;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x0200000>;
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x0200000>;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x4000000>;
+			};
+		};
+	};
+
+	sound_wm8960 {
+		compatible = "mediatek,mt79xx-wm8960-machine";
+		mediatek,platform = <&afe>;
+		audio-routing = "Headphone", "HP_L",
+				"Headphone", "HP_R",
+				"LINPUT1", "AMIC",
+				"RINPUT1", "AMIC";
+		mediatek,audio-codec = <&wm8960>;
+		status = "disabled";
+	};
+
+	sound_si3218x {
+		compatible = "mediatek,mt79xx-si3218x-machine";
+		mediatek,platform = <&afe>;
+		mediatek,ext-codec = <&proslic_spi>;
+		status = "disabled";
+	};
+};
+
+&afe {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcm_pins>;
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c_pins>;
+	status = "disabled";
+
+	wm8960: wm8960@1a {
+		compatible = "wlf,wm8960";
+		reg = <0x1a>;
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+        status = "okay";
+
+        gmac0: mac@0 {
+                compatible = "mediatek,eth-mac";
+                reg = <0>;
+                phy-mode = "2500base-x";
+
+                fixed-link {
+                        speed = <2500>;
+                        full-duplex;
+                        pause;
+                };
+        };
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&phy0>;
+	};
+
+        mdio: mdio-bus {
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+		phy0: ethernet-phy@0 {
+			compatible = "ethernet-phy-id03a2.9461";
+			reg = <0>;
+			phy-mode = "gmii";
+			nvmem-cells = <&phy_calibration>;
+			nvmem-cell-names = "phy-cal-data";
+		};
+
+		switch@0 {
+                        compatible = "mediatek,mt7531";
+                        reg = <31>;
+                        reset-gpios = <&pio 39 0>;
+
+                        ports {
+                                #address-cells = <1>;
+                                #size-cells = <0>;
+
+                                port@0 {
+                                        reg = <0>;
+                                        label = "lan1";
+                                };
+
+                                port@1 {
+                                        reg = <1>;
+                                        label = "lan2";
+                                };
+
+                                port@2 {
+                                        reg = <2>;
+                                        label = "lan3";
+                                };
+
+	            port@3 {
+	                    reg = <3>;
+	                    label = "lan4";
+	            };
+				port@4 {
+					reg = <4>;
+					label = "lan5";
+				};
+
+                                port@6 {
+                                        reg = <6>;
+                                        label = "cpu";
+                                        ethernet = <&gmac0>;
+                                        phy-mode = "2500base-x";
+
+                                        fixed-link {
+                                                speed = <2500>;
+                                                full-duplex;
+                                                pause;
+                                        };
+                                };
+                        };
+                };
+        };
+};
+
+&hnat {
+	mtketh-wan = "eth1";
+	mtketh-lan = "lan";
+	mtketh-max-gmac = <2>;
+	status = "okay";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+	spi_nand: spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+	};
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic_pins>;
+	status = "okay";
+
+	proslic_spi: proslic_spi@0 {
+		compatible = "silabs,proslic_spi";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		spi-cpha = <1>;
+		spi-cpol = <1>;
+		channel_count = <1>;
+		debug_level = <4>;       /* 1 = TRC, 2 = DBG, 4 = ERR */
+		reset_gpio = <&pio 15 0>;
+		ig,enable-spi = <1>;     /* 1: Enable, 0: Disable */
+	};
+};
+
+&pio {
+
+	i2c_pins: i2c-pins-g0 {
+                mux {
+                        function = "i2c";
+                        groups = "i2c0_0";
+                };
+        };
+
+        pcm_pins: pcm-pins-g0 {
+                mux {
+                        function = "pcm";
+                        groups = "pcm";
+                };
+        };
+
+        pwm0_pin: pwm0-pin-g0 {
+                mux {
+                        function = "pwm";
+                        groups = "pwm0_0";
+                };
+        };
+
+        pwm1_pin: pwm1-pin-g0 {
+                mux {
+                        function = "pwm";
+                        groups = "pwm1_0";
+                };
+        };
+
+        pwm2_pin: pwm2-pin {
+                mux {
+                        function = "pwm";
+                        groups = "pwm2";
+                };
+        };
+
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+	spic_pins: spi1-pins {
+		mux {
+			function = "spi";
+			groups = "spi1_1";
+		};
+	};
+
+	uart1_pins: uart1-pins-g1 {
+                mux {
+                        function = "uart";
+                        groups = "uart1_1";
+                };
+        };
+
+	uart2_pins: uart2-pins-g1 {
+		mux {
+                        function = "uart";
+                        groups = "uart2_1";
+                };
+        };
+};
+
+&xhci {
+	mediatek,u3p-dis-msk = <0x0>;
+	phys = <&u2port0 PHY_TYPE_USB2>,
+	       <&u3port0 PHY_TYPE_USB3>;
+	status = "okay";
+};

--- a/target/linux/mediatek/image/mt7981.mk
+++ b/target/linux/mediatek/image/mt7981.mk
@@ -809,3 +809,20 @@ define Device/routerich_ax3000
   DEVICE_PACKAGES := $(MT7981_USB_PKGS)
 endef
 TARGET_DEVICES += routerich_ax3000
+
+define Device/hilink_rm65
+  DEVICE_VENDOR := HiLink
+  DEVICE_MODEL := RM65
+  DEVICE_DTS := mt7981-hilink-rm65
+  DEVICE_DTS_DIR := $(DTS_DIR)/mediatek
+  SUPPORTED_DEVICES := hilink,rm65 mt7981-spim-nand-rfb
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += hilink_rm65

--- a/target/linux/mediatek/mt7981/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/mt7981/base-files/etc/board.d/01_leds
@@ -71,6 +71,10 @@ routerich,ax3000)
 	ucidef_set_led_default "green" "GREEN" "green:status" "0"
 	ucidef_set_led_default "blue" "BLUE" "blue:status" "1"
 	;;
+hilink,rm65)
+	ucidef_set_led_netdev "wan_recv" "WAN RX" "rm65:green:wan_recv" "wan" "rx"
+	ucidef_set_led_netdev "wan_send" "WAN TX" "rm65:green:wan_send" "wan" "tx"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/mediatek/mt7981/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7981/base-files/etc/board.d/02_network
@@ -109,6 +109,9 @@ mediatek_setup_interfaces()
 	*)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
 		;;
+	hilink,rm65)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" eth1
+		;;
 	esac
 }
 

--- a/target/linux/mediatek/mt7981/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7981/base-files/lib/upgrade/platform.sh
@@ -214,6 +214,7 @@ platform_do_upgrade() {
 	*nokia,ea0326gmp* |\
 	*newland,nl-wr8103* |\
 	newland,nl-wr9103 |\
+	hilink,rm65|\
 	*snand*)
 		nand_do_upgrade "$1"
 		;;
@@ -271,7 +272,8 @@ platform_check_image() {
 	nradio,wt9103 |\
 	*snand* |\
 	*emmc* |\
-	routerich,ax3000)
+	routerich,ax3000|\
+	hilink,rm65)
 		# tar magic `ustar`
 		magic="$(dd if="$1" bs=1 skip=257 count=5 2>/dev/null)"
 


### PR DESCRIPTION
Add full support for the HiLink RM65 router based on MediaTek MT7981 with 1GB DDR4 and eMMC storage. This patch introduces the DTS, board initialization scripts, image profile, default configuration and upgrade handling required for full functionality.

Changes include:
 - Add mt7981-hilink-rm65.dts describing memory, NAND, GPIOs, LEDs, keys, Ethernet and WiFi configuration.
 - Add board-specific LED initialization in 01_leds.
 - Add board-specific WAN/LAN mapping in 02_network.
 - Add WiFi SSID auto-suffix uci-defaults script (99-hilink-rm65-ssid) to generate SSID from Factory partition data.
 - Add image build profile for RM65 in mt7981.mk.
 - Extend platform.sh to support sysupgrade compatibility.

The following features have been tested on a retail HiLink RM65 unit:
 - Boot via initramfs and sysupgrade image
 - NAND flashing and upgrade
 - Ethernet LAN/WAN ports
 - 2.4GHz and 5GHz WiFi
 - LED indicators
 - Button functionality
 - The uci-defaults SSID suffix script runs correctly

Tested-by: Ass-Sniper <zoukaiass@gmail.com>